### PR TITLE
CDE-63 Connect collection not found (below button) to email client action

### DIFF
--- a/demo/integration.js
+++ b/demo/integration.js
@@ -75,6 +75,11 @@ export function mapAndInit(datasetMappingFile, additionalDatasetMappingsFiles, d
                             preciseAbbreviation: 1,
                             title: 2,
                             interlexId: 11
+                        },
+                        emailTemplate: {
+                            email: 'support@interlex.org',
+                            title: 'CDE Mapper collection not found',
+                            description: 'This is an email coming from the cde mapper application to flag that a certain collection is missing.'
                         }
                     });
                 },

--- a/lib/components/steps/mapping/CollectionsTab.tsx
+++ b/lib/components/steps/mapping/CollectionsTab.tsx
@@ -13,6 +13,7 @@ interface CollectionsProps {
 function CollectionsTab({changeToNextTab, setDefaultCollection}: CollectionsProps) {
     const {
         collections,
+        emailTemplate
     } = useDataContext();
 
     const collectionKeys = Object.keys(collections);
@@ -71,7 +72,9 @@ function CollectionsTab({changeToNextTab, setDefaultCollection}: CollectionsProp
                             </Button>
                         </Box>
                         <Box sx={{mt: 1.5}}>
-                            <Link href={`mailto:${''}`}>Can’t find the repository you’re looking for? Contact us</Link>
+                            <Link href={`mailto:${emailTemplate.email}?subject=${encodeURIComponent(emailTemplate.title) || ''}&body=${encodeURIComponent(emailTemplate.description) || ''}`}>
+                                Can’t find the repository you’re looking for? Contact us
+                            </Link>
                         </Box>
                     </Stack>
                 </Stack>

--- a/lib/contexts/data/DataContext.ts
+++ b/lib/contexts/data/DataContext.ts
@@ -4,7 +4,8 @@ import {
     Config,
     DatasetMapping,
     HeaderIndexes,
-    Suggestions
+    Suggestions,
+    EmailTemplateParams
 } from "../../models.ts";
 import {ABBREVIATION_INDEX, INTERLEX_ID_INDEX, TITLE_INDEX, VARIABLE_NAME_INDEX} from "../../settings.ts";
 
@@ -20,6 +21,7 @@ export const DataContext = createContext<{
     config: Config;
     setDatasetMapping:  React.Dispatch<React.SetStateAction<DatasetMapping>>;
     setDatasetMappingHeader:  React.Dispatch<React.SetStateAction<string[]>>;
+    emailTemplate: EmailTemplateParams;
 }>({
     name: '',
     datasetSample: [],
@@ -39,6 +41,11 @@ export const DataContext = createContext<{
     },
     setDatasetMapping: () => {},
     setDatasetMappingHeader: () => {},
+    emailTemplate: {
+        email: 'support@interlex.org',
+        title: 'CDE Mapper collection not found',
+        description: 'This is an email coming from the cde mapper application to flag that a certain collection is missing.'
+    }
 });
 
 export const useDataContext = () => useContext(DataContext);

--- a/lib/contexts/data/DataContextProvider.tsx
+++ b/lib/contexts/data/DataContextProvider.tsx
@@ -23,6 +23,7 @@ export const DataContextProvider = ({
                                         collections: rawCollections,
                                         config,
                                         name,
+                                        emailTemplate,
                                         children
                                     }: PropsWithChildren<DataInitParams>) => {
 
@@ -116,6 +117,7 @@ export const DataContextProvider = ({
         headerIndexes,
         collections: collectionsDictionary,
         config,
+        emailTemplate,
         setDatasetMapping,
         setDatasetMappingHeader,
     };

--- a/lib/models.ts
+++ b/lib/models.ts
@@ -10,7 +10,8 @@ export interface DataInitParams {
     headerIndexes?: HeaderIndexes;
     collections: Collection[];
     config: Config;
-    name: string
+    name: string;
+    emailTemplate: EmailTemplateParams;
 }
 
 export interface ServiceInitParams {
@@ -75,4 +76,10 @@ export interface SelectableCollection {
     id: string;
     name: string;
     selected: boolean;
+}
+
+export interface EmailTemplateParams {
+    email: string;
+    title: string;
+    description: string;
 }


### PR DESCRIPTION
Issue #CDE-63
Problem: Connect collection not found (below button) to email client action
Solution: 
Added emailTemplate data into init function and into the context, then, connected in Collections tab 


https://github.com/MetaCell/cde-mapper/assets/67194168/882165e6-ecad-4939-807e-15dacc37de36

