### PR TITLE
CDE-39 Retrieve pairing information

### DIFF
--- a/demo/query.js
+++ b/demo/query.js
@@ -112,7 +112,6 @@ export const getQueryById = (id) => {
 export const getRelatedQuery = (id) => {
     if (id) {
         return {
-            "size": 20,
             "from": 0,
             "query": {
                 "bool": {

--- a/lib/components/steps/mapping/MappingTab.tsx
+++ b/lib/components/steps/mapping/MappingTab.tsx
@@ -22,7 +22,7 @@ import {useDataContext} from "../../../contexts/data/DataContext.ts";
 import {PairingTooltip} from "./PairingTooltip.tsx";
 import {PairingSuggestion} from "./PairingSuggestion.tsx";
 import {EntityType, Option, SelectableCollection, FiltersState} from "../../../models.ts";
-import {getId, getPreciseAbbreviation, getType, isRowMapped} from "../../../helpers/getters.ts";
+import {getId, getType, isRowMapped} from "../../../helpers/getters.ts";
 import {useServicesContext} from "../../../contexts/services/ServicesContext.ts";
 import {mapRowToOption} from "../../../helpers/mappers.ts";
 import {usePairingSuggestions} from "../../../hooks/usePairingSuggestions.ts";
@@ -339,8 +339,7 @@ const MappingTab = ({defaultCollection}: MappingProps) => {
                                                         fontWeight: 500,
                                                         lineHeight: '150%'
                                                     }}>Pairing suggestions</Typography>
-                                                    <PairingTooltip
-                                                        selectedCdeAbbreviation={getPreciseAbbreviation(datasetMapping[variableName], headerIndexes)}/>
+                                                    <PairingTooltip/>
                                                 </AccordionSummary>
                                                 <AccordionDetails>
                                                     <Box pl='2.5625rem'>

--- a/lib/components/steps/mapping/PairingTooltip.tsx
+++ b/lib/components/steps/mapping/PairingTooltip.tsx
@@ -1,25 +1,17 @@
 import {Box, Tooltip, Typography} from "@mui/material";
 import {InfoIcon} from "../../../icons";
 
-export function PairingTooltip(props: { selectedCdeAbbreviation: string }) {
+export function PairingTooltip() {
     return <Tooltip
         title={
             <>
-                <Typography sx={{
-                    fontSize: "0.75rem",
-                    fontWeight: 600,
-                    lineHeight: "142.857%",
-                    marginBottom: "0.25rem",
-                    color: "#fff",
-                }}>We have seen this before</Typography>
                 <Typography sx={{
                     fontSize: "0.75rem",
                     fontWeight: 400,
                     lineHeight: "142.857%",
                     color: "#fff",
                 }}>
-                    {props.selectedCdeAbbreviation} is typically used
-                    with the following fellow CDEs
+                    In this section the CDE Mapper will present fellow CDEs that are meaningful and usually associated with the parent of the pairing suggestions.
                 </Typography>
             </>
         }


### PR DESCRIPTION
Issue #CDE-39
Problem: Retrieve pairing information
Solution: 

- Make accordion component to be expanded by default by using 'defaultExpanded' prop  of mui library
- Use getUnmappedRowsCount() function to get to know number of unmapped rows and control the visibility of pairing suggestions


https://github.com/MetaCell/cde-mapper/assets/67194168/a18e04d6-f4fd-45c5-9c15-1e7cc70271d6

